### PR TITLE
Docs/fix typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,5 @@ To use the latest pinned nightly on your CI, modify your Foundry installation st
 - [startPrank will now override the existing prank instead of erroring](https://github.com/foundry-rs/foundry/pull/4826).
 - [precompiles will not be compatible with all cheatcodes](https://github.com/foundry-rs/foundry/pull/4905).
 - The difficulty and prevrandao cheatcodes now [fail if not used with the correct EVM version](https://github.com/foundry-rs/foundry/pull/4904).
-- The default EVM version will be Shanghai. If you're using an EVM chain which is not compatible with [EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) you need to change your EVM version. See [Matt Solomon's thread](https://twitter.com/msolomon44/status/1656411871635972096) for more information.
+- The default EVM version will be Shanghai. If you're using an EVM chain which is not compatible with [EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) you need to change your EVM version. See [Matt Solomon's thread](https://x.com/msolomon44/status/1656411871635972096) for more information.
 - Non-existent JSON keys are now processed correctly, and `parseJson` returns non-decodable empty bytes if they do not exist. https://github.com/foundry-rs/foundry/pull/5511

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you're experiencing any issues while installing, check out [Getting Help](#ge
     -   Automatic Solidity compiler version detection & installation (under `~/.svm`)
     -   **Incremental compilation & caching**: Only changed files are re-compiled
     -   Parallel compilation
-    -   Non-standard directory structures support (e.g. [Hardhat repos](https://twitter.com/gakonst/status/1461289225337421829))
+    -   Non-standard directory structures support (e.g. [Hardhat repos](https://x.com/gakonst/status/1461289225337421829))
 -   **Tests are written in Solidity** (like in DappTools)
 -   **Fast fuzz testing** with shrinking of inputs & printing of counter-examples
 -   **Fast remote RPC forking mode**, leveraging Rust's async infrastructure like tokio
@@ -121,9 +121,9 @@ If you want to contribute, or follow along with contributor discussion, you can 
 ## Acknowledgements
 
 -   Foundry is a clean-room rewrite of the testing framework [DappTools](https://github.com/dapphub/dapptools). None of this would have been possible without the DappHub team's work over the years.
--   [Matthias Seitz](https://twitter.com/mattsse_): Created [ethers-solc](https://github.com/gakonst/ethers-rs/tree/master/ethers-solc/) which is the backbone of our compilation pipeline, as well as countless contributions to ethers, in particular the `abigen` macros.
--   [Rohit Narurkar](https://twitter.com/rohitnarurkar): Created the Rust Solidity version manager [svm-rs](https://github.com/roynalnaruto/svm-rs) which we use to auto-detect and manage multiple Solidity versions.
--   [Brock Elmore](https://twitter.com/brockjelmore): For extending the VM's cheatcodes and implementing [structured call tracing](https://github.com/foundry-rs/foundry/pull/192), a critical feature for debugging smart contract calls.
+-   [Matthias Seitz](https://x.com/mattsse_): Created [ethers-solc](https://github.com/gakonst/ethers-rs/tree/master/ethers-solc/) which is the backbone of our compilation pipeline, as well as countless contributions to ethers, in particular the `abigen` macros.
+-   [Rohit Narurkar](https://x.com/rohitnarurkar): Created the Rust Solidity version manager [svm-rs](https://github.com/roynalnaruto/svm-rs) which we use to auto-detect and manage multiple Solidity versions.
+-   [Brock Elmore](https://x.com/brockjelmore): For extending the VM's cheatcodes and implementing [structured call tracing](https://github.com/foundry-rs/foundry/pull/192), a critical feature for debugging smart contract calls.
 -   All the other [contributors](https://github.com/foundry-rs/foundry/graphs/contributors) to the [ethers-rs](https://github.com/gakonst/ethers-rs) & [foundry](https://github.com/foundry-rs/foundry) repositories and chatrooms.
 
 [foundry-book]: https://book.getfoundry.sh

--- a/crates/forge/README.md
+++ b/crates/forge/README.md
@@ -415,12 +415,12 @@ available in upstream dapptools:
 
 1. Stack Traces: Currently we do not provide any debug information when a call
    fails. We intend to add a structured printer (something like
-   [this](https://twitter.com/gakonst/status/1434337110111182848) which will
+   [this](https://x.com/gakonst/status/1434337110111182848) which will
    show all the calls, logs and arguments passed across intermediate smart
    contract calls, which should help with debugging.
 1. [Invariant Tests](https://github.com/dapphub/dapptools/blob/master/src/dapp/README.md#invariant-testing)
 1. [Interactive Debugger](https://github.com/dapphub/dapptools/blob/master/src/hevm/README.md#interactive-debugger-key-bindings)
-1. [Code coverage](https://twitter.com/dapptools/status/1435973810545729536)
+1. [Code coverage](https://x.com/dapptools/status/1435973810545729536)
 1. [Gas snapshots](https://github.com/dapphub/dapptools/pull/850/files)
 1. [Symbolic EVM](https://fv.ethereum.org/2020/07/28/symbolic-hevm-release/)
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -6,11 +6,11 @@ This document describes the high-level architecture of Foundry.
 
 Foundry's EVM tooling. This is built around [`revm`](https://github.com/bluealloy/revm) and has additional
 implementation of:
-- [cheatcodes](./cheatcodes.md) a set of solidity calls dedicated to testing which can manipulate the environment in which the execution is run
+- [cheatcodes](./cheatcodes.md): a set of solidity calls dedicated to testing, which can manipulate the environment in which the execution is run
 
 ### `config/`
 
-Includes all of Foundry's settings and how to get them
+Contains all of Foundry's settings and methods for retrieving them.
 
 ### `cli/`
 


### PR DESCRIPTION
Corrected spelling errors in architecture.md, clarified descriptions in 'evm/', 'config/', and 'cli/' sections.
