### PR TITLE
Fix typo Update README.md

### DIFF
--- a/crates/forge/README.md
+++ b/crates/forge/README.md
@@ -206,7 +206,7 @@ contract MyTest {
 
     function testBarExpectedRevert() public {
         vm.expectRevert("My expected revert string");
-        // This would fail *if* we didnt expect revert. Since we expect the revert,
+        // This would fail *if* we didn't expect revert. Since we expect the revert,
         // it doesn't, unless the revert string is wrong.
         foo.bar(101);
     }


### PR DESCRIPTION
# Fix Typo in README.md

## Description
Fixed a typo in the `README.md` file. Specifically, the phrase "didn't" was corrected to "didn't" in the example code under the `testBarExpectedRevert()` function.

## Changes
- Corrected the typo in the explanation in line 206 of `crates/forge/README.md`

## Related Issue
- No related issues
